### PR TITLE
Show own recent tracks when privacy setting "Hide recent listening information" is set on last.fm

### DIFF
--- a/lib/services/lastfm/lastfm.dart
+++ b/lib/services/lastfm/lastfm.dart
@@ -89,6 +89,7 @@ class GetRecentTracksRequest extends PagedRequest<LRecentTracksResponseTrack> {
         if (from != null) 'from': from!.secondsSinceEpoch.toString(),
         if (to != null) 'to': to!.secondsSinceEpoch.toString(),
         'extended': extended ? '1' : '0',
+        'sk': Preferences.key.value,
       });
     } on LException catch (e) {
       if (e.code == 17) {


### PR DESCRIPTION
Added ability to get own recent tracks when privacy setting "Hide recent listening information" is set on last.fm.

This is simply done by also passing the session key with the GetRecentTracksRequest, which allows to view your own recent tracks even when recent listening information is hidden.

Tested on web app only.