### PR TITLE
Get track scrobble history with privacy flag on

### DIFF
--- a/lib/services/lastfm/lastfm.dart
+++ b/lib/services/lastfm/lastfm.dart
@@ -333,6 +333,7 @@ class UserGetTrackScrobblesRequest extends PagedRequest<LUserTrackScrobble> {
       'user': username ?? Preferences.name.value,
       'limit': limit,
       'page': page,
+      'sk': Preferences.key.value,
     });
     return LUserTrackScrobblesResponse.fromJson(rawResponse['trackscrobbles'])
         .tracks;


### PR DESCRIPTION
Added ability to get track scrobble history when privacy setting "Hide recent listening information" is set on last.fm.

_Note: this should be the only feature that did not work with the privacy flag on._